### PR TITLE
Fix handling of HTTPS URLs

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@ const colors = require('colors/safe');
 const open = require('open');
 const child_process = require('child_process');
 
+const urls = require('./urls');
+
 const GET_CURRENT_BRANCH_CMD = 'git symbolic-ref -q --short HEAD';
 const GET_CURRENT_TAG_CMD = 'git describe --tags --exact-match';
 
@@ -27,16 +29,13 @@ try {
         return;
     }
 
-    var url = config['remote "origin"'].url;
+    const url = urls.getHttpsUrlFromRemote(config['remote "origin"'].url);
     const branch = getCurrentBranch();
 
-    if (url.substring(0, 3) == "git") {
-        url = url.substring(4);
-        url = url.substring(0, url.length - 4);
-        url = url.replace(':', '/');
-        open(`http://${url}/tree/${branch}`);
+    if (branch) {
+        open(`${url}/tree/${branch}`);
     } else {
-        open(`${url}`);
+        open(url);
     }
 } catch (e) {
     console.log(colors.red('No repo found!'));

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Open Git project page from the command line",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "bin": {
     "repo": "./index.js"
@@ -23,5 +23,8 @@
     "colors": "^1.1.2",
     "ini": "^1.3.4",
     "open": "0.0.5"
+  },
+  "devDependencies": {
+    "jest": "^20.0.4"
   }
 }

--- a/tests/urls.test.js
+++ b/tests/urls.test.js
@@ -1,0 +1,82 @@
+const urls = require('../urls');
+
+const testUrls = {
+    ssh: [
+        'ssh://git:foo@github.com/robbiegleeson/gistHub.git',
+        'ssh://git@github.com/robbiegleeson/gistHub.git',
+        'ssh://github.com/robbiegleeson/gistHub.git',
+
+        'ssh://git:foo@github.com/robbiegleeson/gistHub',
+        'ssh://git@github.com/robbiegleeson/gistHub',
+        'ssh://github.com/robbiegleeson/gistHub',
+    ],
+    scp: [
+        'git:foo@github.com:robbiegleeson/gistHub.git',
+        'git@github.com:robbiegleeson/gistHub.git',
+
+        'git:foo@github.com:robbiegleeson/gistHub',
+        'git@github.com:robbiegleeson/gistHub',
+    ],
+    https: [
+        'https://git:foo@github.com/robbiegleeson/gistHub.git',
+        'https://git@github.com/robbiegleeson/gistHub.git',
+        'https://github.com/robbiegleeson/gistHub.git',
+
+        'https://git:foo@github.com/robbiegleeson/gistHub',
+        'https://git@github.com/robbiegleeson/gistHub',
+        'https://github.com/robbiegleeson/gistHub',
+    ],
+};
+
+const expectedUrl = 'https://github.com/robbiegleeson/gistHub';
+
+test('SSH URLs are identified correctly', () => {
+  testUrls.ssh.forEach(url => {
+      expect(urls.remoteIsSsh(url)).toBe(true)
+      expect(urls.remoteIsScp(url)).toBe(false);
+      expect(urls.remoteIsHttps(url)).toBe(false);
+  });
+});
+
+test('SCP URLs are identified correctly', () => {
+  testUrls.scp.forEach(url => {
+      expect(urls.remoteIsSsh(url)).toBe(false)
+      expect(urls.remoteIsScp(url)).toBe(true);
+      expect(urls.remoteIsHttps(url)).toBe(false);
+  });
+});
+
+test('HTTPS URLs are identified correctly', () => {
+  testUrls.https.forEach(url => {
+      expect(urls.remoteIsSsh(url)).toBe(false)
+      expect(urls.remoteIsScp(url)).toBe(false);
+      expect(urls.remoteIsHttps(url)).toBe(true);
+  });
+});
+
+test('SSH URLs are transformed correctly', () => {
+    testUrls.ssh.forEach(url => {
+        expect(urls.getHttpsUrlFromSshRemote(url)).toBe(expectedUrl)
+    });
+});
+
+test('SCP URLs are transformed correctly', () => {
+    testUrls.scp.forEach(url => {
+        expect(urls.getHttpsUrlFromScpRemote(url)).toBe(expectedUrl)
+    });
+});
+
+test('HTTPS URLs are transformed correctly', () => {
+    testUrls.https.forEach(url => {
+        expect(urls.getHttpsUrlFromHttpsRemote(url)).toBe(expectedUrl)
+    });
+});
+
+test('Unidentified URLs are transformed correctly', () => {
+    const allTestUrls = Object.keys(testUrls)
+        .reduce((urls, key) => urls.concat(testUrls[key]), []);
+
+    allTestUrls.forEach(url => {
+        expect(urls.getHttpsUrlFromRemote(url)).toBe(expectedUrl)
+    });
+});

--- a/urls.js
+++ b/urls.js
@@ -1,0 +1,45 @@
+function remoteIsSsh(url) {
+    return /^ssh:/.test(url);
+}
+
+function remoteIsScp(url) {
+    return /^(?![^:]+:\/\/)[^@]*@/.test(url);
+}
+
+function remoteIsHttps(url) {
+    return /^https:/.test(url);
+}
+
+function getHttpsUrlFromSshRemote(url) {
+    return url.replace(/^ssh:\/\/([^@]*@)?(.+?)(\.git)?$/, 'https://$2');
+}
+
+function getHttpsUrlFromScpRemote(url) {
+    return url.replace(/^([^@]*@)?([^:]+):?(.+?)(\.git)?$/, 'https://$2/$3');
+}
+
+function getHttpsUrlFromHttpsRemote(url) {
+    return url.replace(/^https:\/\/([^@]*@)?(.+?)(\.git)?$/, 'https://$2');
+}
+
+function getHttpsUrlFromRemote(url) {
+    if (remoteIsSsh(url)) {
+        return getHttpsUrlFromSshRemote(url);
+    } else if(remoteIsScp(url)) {
+        return getHttpsUrlFromScpRemote(url);
+    } else if (remoteIsHttps(url)) {
+        return getHttpsUrlFromHttpsRemote(url);
+    }
+
+    return url;
+}
+
+module.exports = {
+    remoteIsSsh,
+    remoteIsScp,
+    remoteIsHttps,
+    getHttpsUrlFromSshRemote,
+    getHttpsUrlFromScpRemote,
+    getHttpsUrlFromHttpsRemote,
+    getHttpsUrlFromRemote,
+};


### PR DESCRIPTION
Sorry about the bug in the last pull request 😬

This should fix the handling of 'https://' remotes and also add support for 'ssh://' remotes.
I also added some unit tests for the handling of URLs.